### PR TITLE
Better queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 tunnel.sh
 *.yml
+/**/*.pyc
+.cache/
+.pants.*
+dist/

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version: 1.2.1
+pants_version: 1.4.0.dev26
 
 [python-setup]
 # Py3k

--- a/scripts/run_topology/run_topology.py
+++ b/scripts/run_topology/run_topology.py
@@ -165,7 +165,7 @@ def worker(name):
 
 
 @worker("map")
-def map_worker(event, target, source, session, type=None, sleep=1, **kwargs):
+def map_worker(event, target, source, type=None, sleep=1, **kwargs):
   """A worker which just maps over the items on a queue.
 
   Tries to read an item from the work queue, processes it if there is one, otherwise waits 5s.
@@ -177,7 +177,7 @@ def map_worker(event, target, source, session, type=None, sleep=1, **kwargs):
     item = source.get()
     if item is not None:
       with item as item_contents:
-        target(item_contents, session=session, **kwargs)
+        target(item_contents, **kwargs)
     else:
       # FIXME: make this a configurable strategy
       time.sleep(sleep)
@@ -229,7 +229,7 @@ def worker(opts, target_name):
 def main(opts):
   handler = colorlog.StreamHandler()
   handler.setFormatter(
-    colorlog.ColoredFormatter("%(log_color)s %(asctime)s %(levelname)s %(process)d %(module)s %(funcName)s: %(message)s"))
+    colorlog.ColoredFormatter("%(log_color)s %(asctime)s %(levelname)s %(process)d] %(module)s %(funcName)s: %(message)s"))
 
   root_logger = logging.getLogger()
   root_logger.addHandler(handler)

--- a/src/python/skrode/ingesters/test.py
+++ b/src/python/skrode/ingesters/test.py
@@ -1,0 +1,29 @@
+"""
+A test data source.
+
+Pushes a stream of random numbers to the given stream.
+"""
+
+import logging as log
+from random import randint
+from time import sleep
+
+
+def random(event, queue, rate):
+  """Custom queue worker.
+
+  Puts random numbers on a queue, until the event becomes set.
+  """
+  while not event.is_set():
+    for i in range(100):
+      queue.put(randint(1, 10000))
+    log.info("Wrote, napping")
+    sleep(rate)
+
+
+def do_print(number):
+  """Queue map worker target.
+
+  Just logs a number off a queue for diagnostics.
+  """
+  log.info(number)

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,0 +1,35 @@
+---
+# The Redis database connections should go to
+redis:
+  &redis
+  !skrode/redis
+  host: localhost
+  port: 6379
+  db: 0
+
+# The queue topology
+################################################################################
+random_queue:
+  &random_queue
+  !skrode/queue
+  conn: *redis
+  key: /queue/random_data/ready
+
+# Worker queue topology
+################################################################################
+random_data_source:
+  type: custom
+  target: skrode.ingesters.test:random
+  # Nominal args
+  queue: *random_queue
+  rate: 5
+
+random_data_mapper:
+  type: map
+  target: skrode.ingesters.test:do_print
+  source: *random_queue
+
+workers:
+  - random_data_source
+  - random_data_mapper
+  - random_data_mapper

--- a/test/python/skrode/redis/BUILD
+++ b/test/python/skrode/redis/BUILD
@@ -1,0 +1,8 @@
+python_tests(
+  name="test_queues",
+  sources=["test_queues.py"],
+  dependencies=[
+    "//src/python/skrode/redis",
+    "//3rdparty/python:redis",
+  ]
+)

--- a/test/python/skrode/redis/test_queues.py
+++ b/test/python/skrode/redis/test_queues.py
@@ -1,0 +1,29 @@
+from json import dumps, loads
+from threading import Thread, Event
+
+from skrode.redis.workqueue import Producer, Consumer
+
+from redis import StrictRedis
+from pytest import fixture
+
+@fixture
+def conn():
+  rds = StrictRedis("localhost", db=15)
+  rds.flushdb()
+  return rds
+
+
+def test_produce_consume(conn):
+  source = Producer(conn, "test_key", encoder=dumps)
+  sink0 = Consumer(conn, "test_key", "test_key_consumer_0", decoder=loads)
+  sink1 = Consumer(conn, "test_key", "test_key_consumer_1", decoder=loads)
+
+  for i in range(1, 100):
+    source.put(i)
+    assert len(source) == i
+    with sink0.next() as next_value0:
+      with sink1.next() as next_value1:
+        assert i == next_value0 == next_value1
+
+  assert len(sink0) == len(sink1) == 0
+  assert len(source) == len(range(1, 100))


### PR DESCRIPTION
At present, the "queue" implementation I'm using is suitable for bridging several sources into several sinks. There are however a couple problems with this existing queue system. First off, the queues are transient. No data is permanently retained in any queue. This makes it difficult to add new services to an existing Skrode system, as well as to look at the history of what happened in the system.

If Skrode were a real application, I'd probably take this opportunity to do a full rewrite and leverage Apache Kafka. However, it's just a toy. So I'm just gonna prop up the existing Redis queues model I already have to the greatest extent possible.

The new streams model I'm going for:
- Transactional append/push same as Redis lists
- Remove the 2^32-1 length constraint from Redis lists
- Enable constant time access to arbitrary list elements
- Introduce mutable, persistent cursors over queues which provide resumable iteration

I think that at-most-once delivery on a single iterator is an acceptable consistency model, because it naturally provides support for multiple readers on a single cursor without the complexity burden of counting ACKs. Furthermore for Skrode's primary data source - Twitter - continued ingesting with some low loss rate is preferable to ingesting no data. 